### PR TITLE
 Adapt to Julia 1.0/JuMP 0.19/PiecewiseLinearOpt changes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
-julia 0.5
-JuMP 0.14
+julia 0.7
+JuMP 0.19
+MathOptInterface
 PiecewiseLinearOpt

--- a/src/MultilinearOpt.jl
+++ b/src/MultilinearOpt.jl
@@ -1,41 +1,46 @@
 module MultilinearOpt
 
-import JuMP, PiecewiseLinearOpt
+import JuMP, MathOptInterface, PiecewiseLinearOpt
+
+using LinearAlgebra: Symmetric, eigvals
 
 export HyperRectangle, MultilinearFunction, Discretization, outerapproximate, relaxbilinear!
 
-immutable HyperRectangle{D}
+const MOI = MathOptInterface
+const MOIU = MOI.Utilities
+
+struct HyperRectangle{D}
     l::NTuple{D,Float64}
     u::NTuple{D,Float64}
 end
 
-type MultilinearFunction{D}
+mutable struct MultilinearFunction{D}
     bounds::HyperRectangle{D}
     f::Function
 end
 (mlf::MultilinearFunction)(args...) = mlf.f(args...)
 
-type Discretization{D}
+mutable struct Discretization{D}
     d::NTuple{D,Vector{Float64}}
 end
 Discretization(d...) = Discretization(map(t->convert(Vector{Float64},t), d))
 
-type MultilinearData
-    product_dict::Dict{Tuple{JuMP.Variable,JuMP.Variable},JuMP.Variable}
+mutable struct MultilinearData
+    product_dict::Dict{Tuple{JuMP.VariableRef,JuMP.VariableRef},JuMP.VariableRef}
 
-    MultilinearData() = new(Dict{Tuple{JuMP.Variable,JuMP.Variable},JuMP.Variable}())
+    MultilinearData() = new(Dict{Tuple{JuMP.VariableRef,JuMP.VariableRef},JuMP.VariableRef}())
 end
 
-function outerapproximate{D}(m::JuMP.Model, x::NTuple{D,JuMP.Variable}, mlf::MultilinearFunction{D}, disc::Discretization, method)
+function outerapproximate(m::JuMP.Model, x::NTuple{D,JuMP.VariableRef}, mlf::MultilinearFunction{D}, disc::Discretization, method) where {D}
     vform = (method in (:Logarithmic1D,:Logarithmic2D,:ZigZag1D,:ZigZag2D,:Unary))
     r = length(disc.d)
     @assert r == 2
     V = collect(Base.product(disc.d...))
     T = map(t -> mlf.f(t...), V)
-    z = JuMP.@variable(m, basename="z")
+    z = JuMP.@variable(m, base_name="z")
     if vform
         PiecewiseLinearOpt.initPWL!(m)
-        λ = JuMP.@variable(m, [V], lowerbound=0, upperbound=1, basename="λ")
+        λ = JuMP.@variable(m, [V], lower_bound=0, upper_bound=1, base_name="λ")
         JuMP.@constraint(m, sum(λ) == 1)
         for i in 1:r
             JuMP.@constraint(m, sum(λ[v]*v[i] for v in V) == x[i])
@@ -46,12 +51,12 @@ function outerapproximate{D}(m::JuMP.Model, x::NTuple{D,JuMP.Variable}, mlf::Mul
             n = length(I)-1
             n > 1 || continue
             if method == :Logarithmic1D || method == :Logarithmic2D
-                JuMP.@expression(m, γ[j=1:(n+1)], sum(λ[v] for v in V if v[i] == I[j]))
-                PiecewiseLinearOpt.sos2_logarthmic_formulation!(m, γ)
+                γ = JuMP.@expression(m, [j=1:(n+1)], sum(λ[v] for v in V if v[i] == I[j]))
+                PiecewiseLinearOpt.sos2_logarithmic_formulation!(m, γ)
             elseif method == :Unary
-                PiecewiseLinearOpt.sos2_mc_formulation!(m, γ)
+                PiecewiseLinearOpt.sos2_mc_formulation!(m, γ) # TODO: where's γ supposed to come from?
             elseif method == :ZigZag1D || method == :ZigZag2D
-                JuMP.@expression(m, γ[j=1:(n+1)], sum(λ[v] for v in V if v[i] == I[j]))
+                γ = JuMP.@expression(m, [j=1:(n+1)], sum(λ[v] for v in V if v[i] == I[j]))
                 PiecewiseLinearOpt.sos2_zigzag_general_integer_formulation!(m, γ)
             else
                 throw(ArgumentError("Unrecognized method: $method"))
@@ -70,7 +75,7 @@ function outerapproximate{D}(m::JuMP.Model, x::NTuple{D,JuMP.Variable}, mlf::Mul
         x, y = x[iˣ], x[iʸ]
         if method == :MisenerLinear
             λ  = JuMP.@variable(m, [1:NP], Bin)
-            Δy = JuMP.@variable(m, [1:NP], lowerbound=0, upperbound=yᵘ-yˡ)
+            Δy = JuMP.@variable(m, [1:NP], lower_bound=0, upper_bound=yᵘ-yˡ)
             JuMP.@constraint(m, sum(λ) == 1)
             JuMP.@constraints(m, begin
                 xˡ + sum(a*(nP-1)*λ[nP] for nP in 1:NP) ≤ x
@@ -89,8 +94,8 @@ function outerapproximate{D}(m::JuMP.Model, x::NTuple{D,JuMP.Variable}, mlf::Mul
         elseif method == :MisenerLog1
             NL = ceil(Int, log2(NP))
             λ    = JuMP.@variable(m, [1:NL], Bin)
-            Δy   = JuMP.@variable(m, [1:NP], lowerbound=0, upperbound=yᵘ-yˡ)
-            λhat = JuMP.@variable(m, [1:NP], lowerbound=0, upperbound=1)
+            Δy   = JuMP.@variable(m, [1:NP], lower_bound=0, upper_bound=yᵘ-yˡ)
+            λhat = JuMP.@variable(m, [1:NP], lower_bound=0, upper_bound=1)
             JuMP.@constraints(m, begin
                 xˡ + sum(2^(NL-nL)*a*λ[nL] for nL in 1:NL)     ≤ x
                 xˡ + sum(2^(NL-nL)*a*λ[nL] for nL in 1:NL) + a ≥ x
@@ -115,8 +120,8 @@ function outerapproximate{D}(m::JuMP.Model, x::NTuple{D,JuMP.Variable}, mlf::Mul
         elseif method == :MisenerLog2
             NL = ceil(Int, log2(NP))
             λ  = JuMP.@variable(m, [1:NL], Bin)
-            Δy = JuMP.@variable(m, [1:NL], lowerbound=0, upperbound=yᵘ-yˡ)
-            s  = JuMP.@variable(m, [1:NL], lowerbound=0, upperbound=yᵘ-yˡ)
+            Δy = JuMP.@variable(m, [1:NL], lower_bound=0, upper_bound=yᵘ-yˡ)
+            s  = JuMP.@variable(m, [1:NL], lower_bound=0, upper_bound=yᵘ-yˡ)
             JuMP.@constraints(m, begin
                 xˡ +     sum(2^(nL-1)*a*λ[nL] for nL in 1:NL) ≤ x
                 xˡ + a + sum(2^(nL-1)*a*λ[nL] for nL in 1:NL) ≥ x
@@ -142,86 +147,107 @@ function outerapproximate{D}(m::JuMP.Model, x::NTuple{D,JuMP.Variable}, mlf::Mul
     z
 end
 
-function gramian(expr::JuMP.GenericQuadExpr)
-    vars = unique([expr.qvars1; expr.qvars2])
+function gramian(expr::JuMP.GenericQuadExpr{T}) where T
+    vars = unique(Iterators.flatten((var1, var2) for (coeff, var1, var2) in JuMP.quad_terms(expr)))
     varindices = Dict(v => i for (i, v) in enumerate(vars))
     n = length(vars)
-    T = eltype(expr.qcoeffs)
     gramian = zeros(T, n, n)
-    for (var1, var2, coeff) in zip(expr.qvars1, expr.qvars2, expr.qcoeffs)
+    for (coeff, var1, var2) in JuMP.quad_terms(expr)
         ind1, ind2 = varindices[var1], varindices[var2]
         row, col = extrema((ind1, ind2))
-        gramian[row, col] = coeff
+        gramian[row, col] = row == col ? coeff : coeff / 2
     end
     Symmetric(gramian), vars
 end
 
 ispossemidef(mat) = all(eigvals(mat) .>= -1e-10)
-isconcave(x) = isconvex(-x)
 isconvex(x) = error("Could not determine convexity.")
 isconvex(expr::JuMP.GenericAffExpr) = true
 isconvex(expr::JuMP.GenericQuadExpr) = ispossemidef(first(gramian(expr)))
-isconvex(constr::JuMP.LinearConstraint) = true
-function isconvex(constr::JuMP.GenericQuadConstraint)
-    if constr.sense == :(<=)
-        convex = isconvex(constr.terms)
-    elseif constr.sense == :(>=)
-        convex = isconcave(constr.terms)
-    elseif constr.sense == :(==)
-        convex = all(constr.terms.qcoeffs .== 0)
+isconvex(set::MOI.LessThan) = true
+isconvex(set::MOI.GreaterThan) = true
+isconvex(set::MOI.EqualTo) = true
+isconvex(set::MOI.Interval) = true
+
+function isconvex(constr::JuMP.ScalarConstraint)
+    f = JuMP.jump_function(constr)
+    set = JuMP.moi_set(constr)
+    if f isa JuMP.GenericAffExpr
+        return isconvex(set)
+    elseif f isa JuMP.GenericQuadExpr
+        interval = MOI.Interval(set)
+        l, u = interval.lower, interval.upper
+        if l == -Inf && isfinite(u)
+            return isconvex(f)
+        elseif isfinite(l) && u == Inf
+            return isconvex(-f)
+        elseif isfinite(l) && isfinite(u)
+            return all(iszero, coeff for (coeff, _, _) in JuMP.quad_terms(f))
+        else
+            error("Set type $(typeof(set)) not recognized.")
+        end
     else
-        error("Sense $(constr.sense) not recognized")
+        error("Function type $(typeof(f)) not recognized.")
     end
-    convex
 end
 
 function relaxbilinear!(m::JuMP.Model; method=:Logarithmic1D, disc_level::Int = 9)
     # replace each bilinear term in (nonconvex) quadratic constraints with outer approx
     product_dict = Dict() #m.ext[:Multilinear].product_dict
-    if !isconvex(m.obj)
-        aff = linearize_quadratic!(m, m.obj, product_dict, method, disc_level)
-        m.obj = JuMP.QuadExpr(aff)
+    obj = JuMP.objective_function(m)
+    if !isconvex(obj)
+        aff = linearize_quadratic!(m, obj, product_dict, method, disc_level)
+        JuMP.set_objective_function(m, JuMP.QuadExpr(aff))
     end
-    for q in m.quadconstr
-        if !isconvex(q)
-            # TODO: merge terms (i.e. x*y + 2x*y = 3x*y)
-            t = q.terms
-            aff = linearize_quadratic!(m, t, product_dict, method, disc_level)
-            lb = q.sense == :<= ? -Inf : -aff.constant
-            ub = q.sense == :>= ?  Inf : -aff.constant
-            aff.constant = 0
-            lc = JuMP.LinearConstraint(aff, lb, ub)
-            JuMP.addconstraint(m, lc)
+    linearized_quad_constraints = JuMP.ConstraintRef[]
+    for (F, S) in JuMP.list_of_constraint_types(m)
+        if F <: JuMP.GenericQuadExpr
+            for constr in JuMP.all_constraints(m, F, S)
+                q = JuMP.constraint_object(constr)
+                if !isconvex(q)
+                    # TODO: merge terms (i.e. x*y + 2x*y = 3x*y) (use MOIU.canonical, rewrite linearize_quadratic! in terms of MOI.ScalarQuadraticFunction)
+                    f = JuMP.jump_function(q)
+                    set = JuMP.moi_set(q)
+                    aff = linearize_quadratic!(m, f, product_dict, method, disc_level)
+                    interval = MOI.Interval(set)
+                    lb = interval.lower - JuMP.constant(aff)
+                    ub = interval.upper - JuMP.constant(aff)
+                    aff.constant = 0
+                    JuMP.@constraint(m, lb <= aff <= ub)
+                    push!(linearized_quad_constraints, constr)
+                end
+            end
         end
     end
-    empty!(m.quadconstr) # TODO: change with support for convex quadratic
+    for cosntr in linearized_quad_constraints
+        JuMP.delete(m, cosntr)
+    end
     nothing
 end
 
 function linearize_quadratic!(m::JuMP.Model, t::JuMP.QuadExpr, product_dict::Dict, method::Symbol, disc_level::Int)
     aff = copy(t.aff)
-    for i in 1:length(t.qvars1)
-        x, y = t.qvars1[i], t.qvars2[i]
+    for (coeff, x, y) in JuMP.quad_terms(t)
         if haskey(product_dict, (x, y))
             z = product_dict[(x,y)]
         elseif haskey(product_dict, (y, x)) # should be unnecessary branch
             z = product_dict[(y,x)]
         else
             @assert x != y # TODO: support non-bilinear terms
-            lˣ, lʸ = JuMP.getlowerbound(x), JuMP.getlowerbound(y)
-            uˣ, uʸ = JuMP.getupperbound(x), JuMP.getupperbound(y)
+            lˣ, lʸ = JuMP.lower_bound(x), JuMP.lower_bound(y)
+            uˣ, uʸ = JuMP.upper_bound(x), JuMP.upper_bound(y)
             @assert isfinite(lˣ) && isfinite(lʸ) && isfinite(uˣ) && isfinite(uʸ)
             hr = HyperRectangle((lˣ,lʸ), (uˣ,uʸ))
             mlf = MultilinearFunction(hr, (a,b) -> a*b)
             disc_levelˣ = lˣ == uˣ ? 1 : disc_level # if variable is fixed, no need to discretize
             disc_levelʸ = lʸ == uʸ ? 1 : (!(method in (:Logarithmic2D,:ZigZag2D)) ? 2 : disc_level)
-            # disc = Discretization(linspace(lˣ,uˣ,disc_levelˣ), linspace(lʸ,uʸ,disc_levelʸ))
-            disc = Discretization(linspace(lˣ,uˣ,disc_levelˣ), linspace(lʸ,uʸ,disc_levelʸ))
-            z = outerapproximate(m, (t.qvars1[i],t.qvars2[i]), mlf, disc, method)
+            # disc = Discretization(range(lˣ, stop=uˣ, length=disc_levelˣ),  range(lʸ, stop=uʸ, length=disc_levelʸ))
+            disc = Discretization(range(lˣ, stop=uˣ, length=disc_levelˣ),  range(lʸ, stop=uʸ, length=disc_levelʸ))
+            z = outerapproximate(m, (x, y), mlf, disc, method)
             product_dict[(x,y)] = z
             product_dict[(y,x)] = z
         end
-        append!(aff, t.qcoeffs[i]*z)
+        JuMP.add_to_expression!(aff, coeff * z)
     end
     aff
 end

--- a/src/MultilinearOpt.jl
+++ b/src/MultilinearOpt.jl
@@ -155,7 +155,7 @@ function gramian(expr::JuMP.GenericQuadExpr{T}) where T
     for (coeff, var1, var2) in JuMP.quad_terms(expr)
         ind1, ind2 = varindices[var1], varindices[var2]
         row, col = extrema((ind1, ind2))
-        gramian[row, col] = row == col ? coeff : coeff / 2
+        gramian[row, col] += row == col ? coeff : coeff / 2
     end
     Symmetric(gramian), vars
 end
@@ -243,7 +243,7 @@ function linearize_quadratic!(m::JuMP.Model, t::JuMP.QuadExpr, product_dict::Dic
             disc = Discretization(range(lˣ, stop=uˣ, length=disc_levelˣ),  range(lʸ, stop=uʸ, length=disc_levelʸ))
             outerapproximate(m, (x, y), mlf, disc, method)
         end
-        JuMP.add_to_expression!(aff, coeff * z)
+        JuMP.add_to_expression!(aff, coeff / 2 * z)
     end
     aff
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,2 @@
+# BARON
+# Gurobi

--- a/test/adhya1.jl
+++ b/test/adhya1.jl
@@ -1,7 +1,7 @@
 using JuMP, MultilinearOpt, BARON, Gurobi
 
-# m = Model(solver=BaronSolver())
-m = Model(solver=GurobiSolver())
+# m = Model(with_optimizer(Baron.Optimizer))
+m = Model(with_optimizer(Gurobi.Optimizer))
 
 #
 # Problem Topology
@@ -116,4 +116,4 @@ for l in L, j in J
 end
 
 relaxbilinear!(m)
-solve(m)
+optimize!(m)

--- a/test/isconvex.jl
+++ b/test/isconvex.jl
@@ -19,24 +19,24 @@
    @test !MultilinearOpt.isconvex(x + y - z ^2 + x^2 + y^2)
    G = rand(3, 3)
    G = G * G'
-   vars = [x; y; z]
-   @test MultilinearOpt.isconvex(dot(vars, G * vars))
+   vars = [x, y, z]
+   expr = dot(vars, G * vars)
+   G_back, vars_back = MultilinearOpt.gramian(expr)
+   @test vars_back == vars
+   @test G_back ≈ G atol=1e-10
+   @test MultilinearOpt.isconvex(expr)
 
    # LinearConstraint
-   @test MultilinearOpt.isconvex(JuMP.LinearConstraint(JuMP.@constraint(m, x + 3 * y == 0)))
-   @test MultilinearOpt.isconvex(JuMP.LinearConstraint(JuMP.@constraint(m, 2 * x - y >= z)))
-   @test MultilinearOpt.isconvex(JuMP.LinearConstraint(JuMP.@constraint(m, 2 * x - y <= z)))
+   @test MultilinearOpt.isconvex(JuMP.constraint_object(JuMP.@constraint(m, x + 3 * y == 0)))
+   @test MultilinearOpt.isconvex(JuMP.constraint_object(JuMP.@constraint(m, 2 * x - y >= z)))
+   @test MultilinearOpt.isconvex(JuMP.constraint_object(JuMP.@constraint(m, 2 * x - y <= z)))
 
    # QuadConstr
-   JuMP.@constraint(m, x == y * z)
-   @test !MultilinearOpt.isconvex(m.quadconstr[end])
+   @test !MultilinearOpt.isconvex(JuMP.constraint_object(JuMP.@constraint(m, x == y * z)))
 
-   JuMP.@constraint(m, x^2 + y^2 <= z)
-   @test MultilinearOpt.isconvex(m.quadconstr[end])
+   @test MultilinearOpt.isconvex(JuMP.constraint_object(JuMP.@constraint(m, x^2 + y^2 <= z)))
 
-   JuMP.@constraint(m, x^2 + y^2 <= z^2)
-   @test !MultilinearOpt.isconvex(m.quadconstr[end])
+   @test !MultilinearOpt.isconvex(JuMP.constraint_object(JuMP.@constraint(m, x^2 + y^2 <= z^2)))
 
-   JuMP.@constraint(m, -x^2 - y^2 >= -z)
-   @test MultilinearOpt.isconvex(m.quadconstr[end])
+   @test MultilinearOpt.isconvex(JuMP.constraint_object(JuMP.@constraint(m, -x^2 - y^2 >= -z)))
 end

--- a/test/pooling.jl
+++ b/test/pooling.jl
@@ -38,7 +38,7 @@ q = [1.00    6.00    4.00    0.50
 
 b = [75,75,75,75,75,75,75,10,25,30,10]
 
-m = Model(solver=GurobiSolver())
+m = Model(with_optimizer(Gurobi.Optimizer))
 @variable(m, 0 ≤ f[i in N, j in N; (i,j) in A] ≤ maximum(b))
 for i in N
     if i in S
@@ -60,4 +60,5 @@ end
 @objective(m, Min, sum(c[i,j]*f[i,j] for (i,j) in A))
 
 relaxbilinear!(m, method=:Logarithmic2D)
-stat = solve(m)
+optimize!(m)
+stat = JuMP.termination_status(m)

--- a/test/pooling_infra.jl
+++ b/test/pooling_infra.jl
@@ -1,7 +1,7 @@
 using LightXML
 using JuMP, MultilinearOpt, BARON, Gurobi, CPLEX
 
-type Feed
+mutable struct Feed
     id::String
     fc::Float64
     uc::Float64
@@ -10,7 +10,7 @@ type Feed
     qualities::Dict
 end
 
-type Pool
+mutable struct Pool
     id::String
     fc::Float64
     uc::Float64
@@ -18,7 +18,7 @@ type Pool
     qualities::Dict
 end
 
-type Product
+mutable struct Product
     id::String
     ur::Float64
     lb::Float64
@@ -26,14 +26,14 @@ type Product
     qualities::Dict
 end
 
-type Connection
+mutable struct Connection
     source::String
     destination::String
     fc::Float64
     uc::Float64
 end
 
-typealias Quality String
+const Quality = String
 
 c( x::Feed) = x.uc
 AL(x::Feed) = x.lb
@@ -169,50 +169,50 @@ for (roots, dirs, files) in walkdir(filebase), filename in files
     # MisenerLinear
     m1 = pooling_problem(feeds, prods, pools, quals, conns)
     relaxbilinear!(m1, method=:MisenerLinear, disc_level=33)
-    t1 = @elapsed solve(m1)
-    obj1 = getobjectivevalue(m1)
+    t1 = @elapsed optimize!(m1)
+    obj1 = objective_value(m1)
     println(fp, "$filename, MisenerLinear, $t1, $obj1")
 
     # MisenerLog1
     m2 = pooling_problem(feeds, prods, pools, quals, conns)
     relaxbilinear!(m2, method=:MisenerLog1, disc_level=33)
-    t2 = @elapsed solve(m2)
-    obj2 = getobjectivevalue(m2)
+    t2 = @elapsed optimize!(m2)
+    obj2 = objective_value(m2)
     println(fp, "$filename, MisenerLog1, $t2, $obj2")
 
     # MisenerLog2
     m3 = pooling_problem(feeds, prods, pools, quals, conns)
     relaxbilinear!(m3, method=:MisenerLog2, disc_level=33)
-    t3 = @elapsed solve(m3)
-    obj3 = getobjectivevalue(m3)
+    t3 = @elapsed optimize!(m3)
+    obj3 = objective_value(m3)
     println(fp, "$filename, MisenerLog2, $t3, $obj3")
 
     # Logarithmic 1D
     m4 = pooling_problem(feeds, prods, pools, quals, conns)
     relaxbilinear!(m4, method=:Logarithmic1D, disc_level=33)
-    t4 = @elapsed solve(m4)
-    obj4 = getobjectivevalue(m4)
+    t4 = @elapsed optimize!(m4)
+    obj4 = objective_value(m4)
     println(fp, "$filename, Logarithmic1D, $t4, $obj4")
 
     # Logarithmic 2D
     m5 = pooling_problem(feeds, prods, pools, quals, conns)
     relaxbilinear!(m5, method=:Logarithmic2D, disc_level=33)
-    t5 = @elapsed solve(m5)
-    obj5 = getobjectivevalue(m5)
+    t5 = @elapsed optimize!(m5)
+    obj5 = objective_value(m5)
     println(fp, "$filename, Logarithmic2D, $t5, $obj5")
 
     # ZigZag 1D
     m6 = pooling_problem(feeds, prods, pools, quals, conns)
     relaxbilinear!(m6, method=:ZigZag1D, disc_level=33)
-    t6 = @elapsed solve(m6)
-    obj6 = getobjectivevalue(m6)
+    t6 = @elapsed optimize!(m6)
+    obj6 = objective_value(m6)
     println(fp, "$filename, ZigZag1D, $t6, $obj6")
 
     # ZigZag 2D
     m7 = pooling_problem(feeds, prods, pools, quals, conns)
     relaxbilinear!(m7, method=:ZigZag2D, disc_level=33)
-    t7 = @elapsed solve(m7)
-    obj7 = getobjectivevalue(m7)
+    t7 = @elapsed optimize!(m7)
+    obj7 = objective_value(m7)
     println(fp, "$filename, ZigZag2D, $t7, $obj7")
 
     flush(fp)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
 using MultilinearOpt
-using Base.Test
+using JuMP
+using LinearAlgebra
+using Test
 
 include("isconvex.jl")
-
-# write your own tests here
-@test 1 == 2
+# include("adhya1.jl")
+# include("pooling_infra.jl")
+# include("pooling.jl")


### PR DESCRIPTION
Requires https://github.com/joehuchette/PiecewiseLinearOpt.jl/pull/34.

I've ensured locally that `adhya1.jl` and `pooling.jl` can be run without error, but since they don't assert anything, please check my changes carefully. I can't run `pooling_infra.jl` due to missing assets, but I tried to update the syntax as best I could.

Also fixed this TODO in the process:

https://github.com/joehuchette/MultilinearOpt.jl/blob/b58b45c9991ac423e0832242f99ac1391a33c5fa/src/MultilinearOpt.jl#L197


