### PR TITLE
Add Project.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml
+

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,18 @@
+name = "MultilinearOpt"
+uuid = "056e1bd9-d272-5a02-876b-3036887dbe22"
+
+[deps]
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+PiecewiseLinearOpt = "0f51c51e-adfa-5141-8a04-d40246b8977c"
+
+[compat]
+JuMP = "≥ 0.19.0"
+julia = "≥ 0.7.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 0.7
-JuMP 0.19
-MathOptInterface
-PiecewiseLinearOpt

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,0 @@
-# BARON
-# Gurobi


### PR DESCRIPTION
This patch adds `Project.toml` generated by Pkg.jl's `gen_project.jl` script
and removes `REQUIRE` file.

Will require https://github.com/joehuchette/PiecewiseLinearOpt.jl/pull/35 and a new PiecewiseLinearOpt version tag.