### PR TITLE
More tests, fix division by two logic error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml
+

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,8 @@ JuMP = "≥ 0.19.0"
 julia = "≥ 0.7.0"
 
 [extras]
+Gurobi = "2e9cd046-0924-5485-92f1-d5272153d98b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Gurobi"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,18 @@
+name = "MultilinearOpt"
+uuid = "056e1bd9-d272-5a02-876b-3036887dbe22"
+
+[deps]
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+PiecewiseLinearOpt = "0f51c51e-adfa-5141-8a04-d40246b8977c"
+
+[compat]
+JuMP = "≥ 0.19.0"
+julia = "≥ 0.7.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 0.7
-JuMP 0.19
-MathOptInterface
-PiecewiseLinearOpt

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,0 @@
-# BARON
-# Gurobi

--- a/test/adhya1.jl
+++ b/test/adhya1.jl
@@ -1,6 +1,9 @@
-using JuMP, MultilinearOpt, BARON, Gurobi
+using JuMP, MultilinearOpt
 
+# using BARON
 # m = Model(with_optimizer(Baron.Optimizer))
+
+using Gurobi
 m = Model(with_optimizer(Gurobi.Optimizer))
 
 #

--- a/test/constraint_violation.jl
+++ b/test/constraint_violation.jl
@@ -15,7 +15,7 @@ function test_constraint_violation(f, xbounds::NTuple{2}, ybounds::NTuple{2};
     relaxbilinear!(m, method=method, disc_level=disc_level)
     for i = 1 : num_tests
         x̄ = xbounds[1] + rand(rng) * (xbounds[2] - xbounds[1])
-        ȳ = xbounds[1] + rand(rng) * (xbounds[2] - xbounds[1])
+        ȳ = ybounds[1] + rand(rng) * (ybounds[2] - ybounds[1])
         z̄ = f(x̄, ȳ) + rand(rng) - 0.5
         @objective m Min sum(x -> x^2, [x, y, z] - [x̄, ȳ, z̄])
         optimize!(m)

--- a/test/constraint_violation.jl
+++ b/test/constraint_violation.jl
@@ -1,0 +1,65 @@
+using MultilinearOpt
+using JuMP
+using Gurobi
+using Test
+using Random
+using LinearAlgebra
+
+function test_constraint_violation(f, xbounds::NTuple{2}, ybounds::NTuple{2};
+        method::Symbol, disc_level::Integer, rng::AbstractRNG, atol::Real, num_tests::Integer)
+    m = Model(with_optimizer(Gurobi.Optimizer, OutputFlag=0))
+    @variable m x lower_bound=xbounds[1] upper_bound=xbounds[2]
+    @variable m y lower_bound=ybounds[1] upper_bound=ybounds[2]
+    @variable m z
+    @constraint m z == f(x, y)
+    relaxbilinear!(m, method=method, disc_level=disc_level)
+    for i = 1 : num_tests
+        x̄ = xbounds[1] + rand(rng) * (xbounds[2] - xbounds[1])
+        ȳ = xbounds[1] + rand(rng) * (xbounds[2] - xbounds[1])
+        z̄ = f(x̄, ȳ) + rand(rng) - 0.5
+        @objective m Min sum(x -> x^2, [x, y, z] - [x̄, ȳ, z̄])
+        optimize!(m)
+        bounds_tol = 1e-8
+        @test xbounds[1] - bounds_tol <= value(x) <= xbounds[2] + bounds_tol
+        @test ybounds[1] - bounds_tol <= value(y) <= ybounds[2] + bounds_tol
+        violation = f(value(x), value(y)) - value(z)
+        # @show violation
+        # @show value(x) value(y) value(z)
+        # println()
+        @test violation ≈ 0 atol=atol
+    end
+end
+
+@testset "constraint violation" begin
+    rng = MersenneTwister(1)
+    atol = 1.1e-2
+    num_tests = 20
+    xbounds = (-0.5, 0.5)
+    ybounds = (-0.4, 0.6)
+    for (method, disc_level) in  [
+            (:Logarithmic1D, 31),
+            (:Logarithmic2D, 6),
+            (:ZigZag1D, 31),
+            (:ZigZag2D, 6),
+            # (:Unary, 31) # broken
+            (:MisenerLinear, 31),
+            (:MisenerLog1, 31),
+            (:MisenerLog2, 31)]
+
+        test_constraint_violation(*, xbounds, ybounds;
+            method=method, disc_level=disc_level,
+            atol=atol, rng=rng, num_tests=num_tests)
+
+        test_constraint_violation((x, y) -> x * y + 3, xbounds, ybounds;
+            method=method, disc_level=disc_level,
+            atol=atol, rng=rng, num_tests=num_tests)
+
+        test_constraint_violation((x, y) -> x^2, xbounds, ybounds;
+            method=method, disc_level=disc_level,
+            atol=atol, rng=rng, num_tests=num_tests)
+
+        test_constraint_violation((x, y) -> x^2 + x * y - y, xbounds, ybounds;
+            method=method, disc_level=disc_level,
+            atol=2 * atol, rng=rng, num_tests=num_tests)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,10 @@ using JuMP
 using LinearAlgebra
 using Test
 
+using Gurobi
+
 include("isconvex.jl")
+include("constraint_violation.jl")
 include("adhya1.jl")
 # include("pooling_infra.jl") # requires unavailable csv file
 include("pooling.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,6 @@ using LinearAlgebra
 using Test
 
 include("isconvex.jl")
-# include("adhya1.jl")
-# include("pooling_infra.jl")
-# include("pooling.jl")
+include("adhya1.jl")
+# include("pooling_infra.jl") # requires unavailable csv file
+include("pooling.jl")


### PR DESCRIPTION
On top of #6.

Add a more rigorous constraint violation test and include some of the older tests. Turns out the division by two from https://github.com/joehuchette/MultilinearOpt.jl/pull/4#discussion_r264458998 *was* wrong. I also verified using this test that quadratic terms (`x == y`) work, so I removed that assertion error. Granted, the relaxation could probably be better in that case, but at least it works. Note also that the `:Unary` method appears to be broken currently.